### PR TITLE
Enable hydrate feature in frontend

### DIFF
--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib", "rlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-app.path = "../app"
+app = { path = "../app", default-features = false, features = ["hydrate"] }
 leptos = { workspace = true, features = [ "hydrate" ] }
 
 console_error_panic_hook.workspace = true


### PR DESCRIPTION
When using this template and running `cargo leptos watch`, the project builds and runs but when clicking on the `Click Me` button nothing happens.

I think this [commit](https://github.com/leptos-rs/start-axum-workspace/commit/0e4fa12b595845bf99c7f5b9bc2f4161d54c8a25) caused the issue as it removed `hydrate` as a default feature in app without enabling the feature in the frontend crate.

This PR enable the `hydrate` feature for the app in the frontend crate.