### PR TITLE
Dependency splitting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,15 +14,10 @@ leptos_router = { version = "0.3", default-features = false }
 leptos_dom = { version = "0.3", default-features = false }
 leptos_axum = { version = "0.3" }
 
-axum = "0.6.11"
 cfg-if = "1.0.0"
 http = "0.2.9"
 log = "0.4.17"
-simple_logger = "4.1.0"
 thiserror = "1.0.40"
-tokio = { version = "1.26.0", features = ["full"] }
-tower = { version = "0.4.13", features = ["full"] }
-tower-http = { version = "0.4.0", features = ["full"] }
 
 # See https://github.com/akesson/cargo-leptos for documentation of all the parameters.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ opt-level = 'z'
 
 [workspace.dependencies]
 leptos = { version = "0.3", default-features = false }
-leptos_dom = { version = "0.3", default-features = false }
 leptos_axum = { version = "0.3" }
 log = "0.4.17"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,9 @@ opt-level = 'z'
 
 [workspace.dependencies]
 leptos = { version = "0.3", default-features = false }
-leptos_meta = { version = "0.3", default-features = false }
-leptos_router = { version = "0.3", default-features = false }
 leptos_dom = { version = "0.3", default-features = false }
 leptos_axum = { version = "0.3" }
-
-cfg-if = "1.0.0"
-http = "0.2.9"
 log = "0.4.17"
-thiserror = "1.0.40"
 
 # See https://github.com/akesson/cargo-leptos for documentation of all the parameters.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,6 @@ leptos_axum = { version = "0.3" }
 
 axum = "0.6.11"
 cfg-if = "1.0.0"
-console_error_panic_hook = "0.1.7"
-console_log = "1.0.0"
 http = "0.2.9"
 log = "0.4.17"
 simple_logger = "4.1.0"
@@ -25,7 +23,6 @@ thiserror = "1.0.40"
 tokio = { version = "1.26.0", features = ["full"] }
 tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.4.0", features = ["full"] }
-wasm-bindgen = "0.2.84"
 
 # See https://github.com/akesson/cargo-leptos for documentation of all the parameters.
 

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2021"
 
 [dependencies]
 leptos.workspace = true
-leptos_meta.workspace = true
-leptos_router.workspace = true
+leptos_meta = { version = "0.3", default-features = false }
+leptos_router = { version = "0.3", default-features = false }
 leptos_axum = { workspace = true, optional = true }
 
-http.workspace = true
-cfg-if.workspace = true
-thiserror.workspace = true
+http = "0.2.9"
+cfg-if = "1.0.0"
+thiserror = "1.0.40"
 
 [features]
 default = []

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "rlib"]
 app = { path = "../app", default-features = false, features = ["hydrate"] }
 leptos = { workspace = true, features = [ "hydrate" ] }
 
-console_error_panic_hook.workspace = true
-console_log.workspace = true
+console_error_panic_hook = "0.1.7"
+console_log = "1.0.0"
 log.workspace = true
-wasm-bindgen.workspace = true
+wasm-bindgen = "0.2.86"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,9 +10,9 @@ app = { path = "../app", default-features = false, features = ["ssr"] }
 leptos = { workspace = true, features = [ "ssr" ]}
 leptos_axum.workspace = true
 
-axum.workspace = true
-simple_logger.workspace = true
-tokio.workspace = true
-tower.workspace = true
-tower-http.workspace = true
+axum = "0.6.11"
+simple_logger = "4.1.0"
+tokio = { version = "1.26.0", features = ["full"] }
+tower = { version = "0.4.13", features = ["full"] }
+tower-http = { version = "0.4.0", features = ["full"] }
 log.workspace = true


### PR DESCRIPTION
First open source PR :)

I was confused as to why some crates were defined in the workspace when they were only used by one project so I split them.

One thing to note is that I had to set the `wasm-bindgen` dependency to `"=0.2.84"` on my end in order to build it but I did not want to commit that as it could just be dependent on my toolchain(`v1.71.0-nightly`).
EDIT: I updated my `cargo-leptos` to the current git commit and that seemed to make `wasm-bindgen="0.2.86"` work :)