### PR TITLE
Fix #7 by updating the fileserv error handling and adding a Router fallback

### DIFF
--- a/app/src/error_template.rs
+++ b/app/src/error_template.rs
@@ -54,18 +54,17 @@ pub fn ErrorTemplate(
     }}
 
     view! {
-        <h1>{if errors.len() > 1 {"Errors"} else {"Error"}}</h1>
+        <h1>{if errors.len() > 1 { "Errors" } else { "Error" }}</h1>
         <For
             // a function that returns the items we're iterating over; a signal is fine
-            each= move || {errors.clone().into_iter().enumerate()}
+            each=move || { errors.clone().into_iter().enumerate() }
             // a unique key for each item as a reference
             key=|(index, _error)| *index
             // renders each item to a view
             children=move |error| {
                 let error_string = error.1.to_string();
-                let error_code= error.1.status_code();
+                let error_code = error.1.status_code();
                 view! {
-
                     <h2>{error_code.to_string()}</h2>
                     <p>"Error: " {error_string}</p>
                 }

--- a/app/src/error_template.rs
+++ b/app/src/error_template.rs
@@ -35,7 +35,7 @@ pub fn ErrorTemplate(
         },
     };
     // Get Errors from Signal
-    let errors = errors.get();
+    let errors = errors.get_untracked();
 
     // Downcast lets us take a type that implements `std::error::Error`
     let errors: Vec<AppError> = errors

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1,3 +1,5 @@
+use crate::error_template::{ErrorTemplate, AppError};
+
 use leptos::*;
 use leptos_meta::*;
 use leptos_router::*;
@@ -20,7 +22,11 @@ pub fn App() -> impl IntoView {
         <Title text="Welcome to Leptos"/>
 
         // content for this welcome page
-        <Router>
+        <Router fallback=|| {
+            let mut outside_errors = Errors::default();
+            outside_errors.insert_with_default_key(AppError::NotFound);
+            view! { <ErrorTemplate outside_errors/> }.into_view()
+        }>
             <main>
                 <Routes>
                     <Route path="" view=HomePage/>

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -1,4 +1,4 @@
-use crate::error_template::{ErrorTemplate, AppError};
+use crate::error_template::{AppError, ErrorTemplate};
 
 use leptos::*;
 use leptos_meta::*;
@@ -12,10 +12,6 @@ pub fn App() -> impl IntoView {
     provide_meta_context();
 
     view! {
-
-
-        // injects a stylesheet into the document <head>
-        // id=leptos means cargo-leptos will hot-reload this stylesheet
         <Stylesheet id="leptos" href="/pkg/start-axum-workspace.css"/>
 
         // sets the document title

--- a/server/src/fileserv.rs
+++ b/server/src/fileserv.rs
@@ -1,3 +1,4 @@
+use app::App;
 use app::error_template::AppError;
 use app::error_template::ErrorTemplate;
 use axum::response::Response as AxumResponse;
@@ -22,13 +23,8 @@ pub async fn file_and_error_handler(
     if res.status() == StatusCode::OK {
         res.into_response()
     } else {
-        let mut errors = Errors::default();
-        errors.insert_with_default_key(AppError::NotFound);
-        let handler = leptos_axum::render_app_to_stream(
-            options.to_owned(),
-            move || view! { <ErrorTemplate outside_errors=errors.clone()/> },
-        );
-        handler(req).await.into_response()
+        let handler = leptos_axum::render_app_to_stream(options.to_owned(), move || view!{<App/>});
+            handler(req).await.into_response()
     }
 }
 

--- a/server/src/fileserv.rs
+++ b/server/src/fileserv.rs
@@ -1,6 +1,6 @@
-use app::App;
 use app::error_template::AppError;
 use app::error_template::ErrorTemplate;
+use app::App;
 use axum::response::Response as AxumResponse;
 use axum::{
     body::{boxed, Body, BoxBody},
@@ -23,8 +23,8 @@ pub async fn file_and_error_handler(
     if res.status() == StatusCode::OK {
         res.into_response()
     } else {
-        let handler = leptos_axum::render_app_to_stream(options.to_owned(), move || view!{<App/>});
-            handler(req).await.into_response()
+        let handler = leptos_axum::render_app_to_stream(options.to_owned(), move || view! { <App/> });
+        handler(req).await.into_response()
     }
 }
 


### PR DESCRIPTION
This pull request fixes #7 by adding a fallback route to Router in the `app/lib.rs` file, and removing some server side error handling from `server/fileserv.rs` to allow the app to deal with it, fixing a csr vs ssr error that was occuring beforehand.
`cargo fmt` & `leptosfmt .` have also been run.