### PR TITLE
 Add a "nightly" option to the project generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ lto = true
 opt-level = 'z'
 
 [workspace.dependencies]
-leptos = { version = "0.6", features = ["nightly"] }
-leptos_meta = { version = "0.6", features = ["nightly"] }
-leptos_router = { version = "0.6", features = ["nightly"] }
+leptos = { version = "0.6"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
+leptos_meta = { version = "0.6"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
+leptos_router = { version = "0.6"{% if nightly == "Yes" %}, features = ["nightly"]{% endif %} }
 leptos_axum = { version = "0.6" }
 
 axum = "0.7"

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,5 @@
+[placeholders]
+nightly = { prompt = "Use nightly features?", choices = ["No", "Yes"], default = "No", type = "string"}
+
+[conditional.'nightly == "No"']
+ignore = ["rust-toolchain.toml"]


### PR DESCRIPTION
This adds the "nightly" prompt to the project generation as it is already the case for the non workspace axum starter.